### PR TITLE
Add support for Shapeshifter Menu & New Command

### DIFF
--- a/src/AleLuduMod/AleLuduMod.csproj
+++ b/src/AleLuduMod/AleLuduMod.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <TargetFramework>net6.0</TargetFramework>
-        <Version>1.0.6</Version>
+        <Version>1.1.0</Version>
         <Authors>townofus.pl, OrzechMC, Bubeu</Authors>
         
         <LangVersion>latest</LangVersion>

--- a/src/AleLuduMod/AleLuduMod.csproj
+++ b/src/AleLuduMod/AleLuduMod.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <TargetFramework>net6.0</TargetFramework>
-        <Version>1.0.5</Version>
+        <Version>1.0.6</Version>
         <Authors>townofus.pl, OrzechMC, Bubeu</Authors>
         
         <LangVersion>latest</LangVersion>

--- a/src/AleLuduMod/AleLuduModPlugin.cs
+++ b/src/AleLuduMod/AleLuduModPlugin.cs
@@ -4,10 +4,7 @@ using BepInEx.Unity.IL2CPP;
 using HarmonyLib;
 using Reactor;
 using BepInEx.Configuration;
-using Reactor.Networking;
-using Reactor.Networking.Attributes;
 using System.Linq;
-using BepInEx.Logging;
 
 namespace AleLuduMod;
 
@@ -18,16 +15,16 @@ namespace AleLuduMod;
 [BepInDependency("com.slushiegoose.townofus", BepInDependency.DependencyFlags.SoftDependency)] // load after town of us
 public partial class AleLuduModPlugin : BasePlugin
 {
-    public const int MaxPlayers = 35;
-    public const int MaxImpostors = 35 / 2;
+    public const int MaxPlayers = 36;
+    public const int MaxImpostors = 36 / 2;
     public static ConfigEntry<bool> Force4Columns { get; set; }
     private Harmony Harmony { get; } = new(Id);
 
     public override void Load()
     { 
-        NormalGameOptionsV09.RecommendedImpostors = NormalGameOptionsV09.MaxImpostors = Enumerable.Repeat(35, 35).ToArray();
-        NormalGameOptionsV09.MinPlayers = Enumerable.Repeat(4, 35).ToArray();
-        HideNSeekGameOptionsV09.MinPlayers = Enumerable.Repeat(4, 35).ToArray();
+        NormalGameOptionsV09.RecommendedImpostors = NormalGameOptionsV09.MaxImpostors = Enumerable.Repeat(36, 36).ToArray();
+        NormalGameOptionsV09.MinPlayers = Enumerable.Repeat(4, 36).ToArray();
+        HideNSeekGameOptionsV09.MinPlayers = Enumerable.Repeat(4, 36).ToArray();
 
         Force4Columns = Config.Bind("Settings", "Force 4 columns", true, "Always display 4 columns in meeting, vitals, etc.");
 

--- a/src/AleLuduMod/Components/ShapeshifterMenuBehaviour.cs
+++ b/src/AleLuduMod/Components/ShapeshifterMenuBehaviour.cs
@@ -1,0 +1,46 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Il2CppInterop.Runtime.Attributes;
+using Reactor.Utilities.Attributes;
+using UnityEngine;
+
+namespace AleLuduMod.Components;
+
+[RegisterInIl2Cpp]
+public class ShapeshifterBehaviour : MonoBehaviour
+{
+    public ShapeshifterBehaviour(IntPtr ptr) : base(ptr)
+    {
+    }
+
+    public ShapeshifterMinigame shapeshifterMinigame = null!;
+    [HideFromIl2Cpp] public IEnumerable<ShapeshifterPanel> Targets => shapeshifterMinigame.potentialVictims.ToArray();
+
+    public void Start()
+    {
+        if (Targets.Count() < 16 && !AleLuduModPlugin.Force4Columns.Value)
+        {
+            // dont change layout if players count is below 16
+            return;
+        }
+
+        var i = 0;
+
+        foreach (var panel in Targets)
+        {
+            panel.gameObject.SetActive(true);
+
+            var row = i / 4;
+            var col = i % 4;
+            var buttonTransform = panel.transform;
+            buttonTransform.localScale *= 0.75f;
+            buttonTransform.localPosition = new Vector3(
+                                            shapeshifterMinigame.XStart + shapeshifterMinigame.XOffset * col * 0.75f - 0.375f,
+                                            shapeshifterMinigame.YStart + shapeshifterMinigame.YOffset * row * 0.75f,
+                                            buttonTransform.localPosition.z
+                                        );
+            i++;
+        }
+    }
+}

--- a/src/AleLuduMod/Patches/ChatCommands.cs
+++ b/src/AleLuduMod/Patches/ChatCommands.cs
@@ -18,8 +18,7 @@ namespace AleLuduMod.Patches
                     return true;
 
                 // After entering the command, when you try to join the lobby it will show "X/15". Only after the game is over will there be a larger lobby.
-                // Other mods that have access to chat commands like "Town Of Us" will always display “Invalid Command.”
-                if (chatText.StartsWith("/limit "))
+                if (chatText.StartsWith("!limit "))
                 {
                     if (GameData.Instance.GetHost() == sourcePlayer.Data)
                     {
@@ -58,7 +57,7 @@ namespace AleLuduMod.Patches
                             if (sourcePlayer.PlayerId == PlayerControl.LocalPlayer.PlayerId)
                             {
                                 error = true;
-                                HudManager.Instance.Chat.AddChat(PlayerControl.LocalPlayer, "Use /limit [number]. Example: /limit 20");
+                                HudManager.Instance.Chat.AddChat(PlayerControl.LocalPlayer, "Use !limit [number]. Example: !limit 20");
                             }
                             return false;
                         }

--- a/src/AleLuduMod/Patches/ChatCommands.cs
+++ b/src/AleLuduMod/Patches/ChatCommands.cs
@@ -37,10 +37,7 @@ namespace AleLuduMod.Patches
                                     }
                                     return false;
                                 }
-                                catch (System.Exception)
-                                {
-                                    return false;
-                                }
+                                catch { }
                             }
                             else
                             {

--- a/src/AleLuduMod/Patches/ChatCommands.cs
+++ b/src/AleLuduMod/Patches/ChatCommands.cs
@@ -1,0 +1,120 @@
+﻿using AmongUs.GameOptions;
+using HarmonyLib;
+
+namespace AleLuduMod.Patches
+{
+    public class ChatCommands
+    {
+        public static bool system = false;
+        public static bool error = false;
+        public static bool noaccess = false;
+
+        [HarmonyPatch(typeof(ChatController), nameof(ChatController.AddChat))]
+        public class Commands
+        {
+            public static bool Prefix(ChatController __instance, [HarmonyArgument(0)] PlayerControl sourcePlayer , ref string chatText)
+            {
+                if (__instance != HudManager.Instance.Chat)
+                    return true;
+
+                // After entering the command, when you try to join the lobby it will show "X/15". Only after the game is over will there be a larger lobby.
+                // Other mods that have access to chat commands like "Town Of Us" will always display “Invalid Command.”
+                if (chatText.StartsWith("/limit "))
+                {
+                    if (GameData.Instance.GetHost() == sourcePlayer.Data)
+                    {
+                        string[] args = chatText.Split(' ');
+                        if (args.Length > 1 && int.TryParse(args[1], out int newLimit))
+                        {
+                            if (newLimit >= 4 && newLimit <= 35)
+                            {
+                                try
+                                {
+                                    GameOptionsManager.Instance.CurrentGameOptions.SetInt(Int32OptionNames.MaxPlayers, newLimit);
+                                    if (sourcePlayer.PlayerId == PlayerControl.LocalPlayer.PlayerId)
+                                    {
+                                        system = true;
+                                        HudManager.Instance.Chat.AddChat(PlayerControl.LocalPlayer, $"A player limit has been set for: <color=#D91919FF>{newLimit}</color>");
+                                    }
+                                    return false;
+                                }
+                                catch (System.Exception)
+                                {
+                                    return false;
+                                }
+                            }
+                            else
+                            {
+                                if (sourcePlayer.PlayerId == PlayerControl.LocalPlayer.PlayerId)
+                                {
+                                    error = true;
+                                    HudManager.Instance.Chat.AddChat(PlayerControl.LocalPlayer, "The limit must be between 4 and 35.");
+                                }
+                                return false;
+                            }
+                        }
+                        else
+                        {
+                            if (sourcePlayer.PlayerId == PlayerControl.LocalPlayer.PlayerId)
+                            {
+                                error = true;
+                                HudManager.Instance.Chat.AddChat(PlayerControl.LocalPlayer, "Use /limit [number]. Example: /limit 20");
+                            }
+                            return false;
+                        }
+                    }
+                    else if (sourcePlayer.PlayerId == PlayerControl.LocalPlayer.PlayerId)
+                    {
+                        if (sourcePlayer.PlayerId == PlayerControl.LocalPlayer.PlayerId)
+                        {
+                            noaccess = true;
+                            HudManager.Instance.Chat.AddChat(PlayerControl.LocalPlayer, "You don't have access to this command!");
+                        }
+                        return false;
+                    }
+                    return sourcePlayer.PlayerId == PlayerControl.LocalPlayer.PlayerId;
+                }
+                return true;
+            }
+        }
+
+        [HarmonyPatch(typeof(ChatBubble), nameof(ChatBubble.SetName))]
+        public class ChatFixName
+        {
+            public static bool Prefix(ChatBubble __instance)
+            {
+                if (error)
+                {
+                    __instance.NameText.text = "ERROR";
+                    __instance.NameText.color = Palette.ImpostorRed;
+                    __instance.NameText.ForceMeshUpdate(true, true);
+                    __instance.Xmark.enabled = true;
+                    __instance.votedMark.enabled = false;
+                    error = false;
+                    return false;
+                }
+                else if (system)
+                {
+                    __instance.NameText.text = "SYSTEM MESSAGE";
+                    __instance.NameText.color = Palette.CrewmateBlue;
+                    __instance.NameText.ForceMeshUpdate(true, true);
+                    __instance.Xmark.enabled = false;
+                    __instance.votedMark.enabled = false;
+                    system = false;
+                    return false;
+                }
+                else if (noaccess)
+                {
+                    __instance.NameText.text = "NO ACCESS";
+                    __instance.NameText.color = Palette.Blue;
+                    __instance.NameText.ForceMeshUpdate(true, true);
+                    __instance.Xmark.enabled = true;
+                    __instance.votedMark.enabled = false;
+                    noaccess = false;
+                    return false;
+                }
+                else return true;
+            }
+        }
+    }
+}

--- a/src/AleLuduMod/Patches/PagingPatches.cs
+++ b/src/AleLuduMod/Patches/PagingPatches.cs
@@ -23,4 +23,12 @@ internal static class PagingPatches
         }
     }
 
+    [HarmonyPatch(typeof(ShapeshifterMinigame), nameof(ShapeshifterMinigame.Begin))]
+    public static class ShapeshifterMinigameBeginPatch
+    {
+        public static void Postfix(ShapeshifterMinigame __instance)
+        {
+            __instance.gameObject.AddComponent<ShapeshifterBehaviour>().shapeshifterMinigame = __instance;
+        }
+    }
 }


### PR DESCRIPTION
<img width="1605" height="629" alt="image" src="https://github.com/user-attachments/assets/e51850c0-126f-4ddb-a729-c1e3130e2cec" />

New Commands:

`!limit` - Command available only to the host. With this command you can set the player limit in the lobby from 4 to 35 players. Example: `!limit [number]`, `!limit 20`. Suggestion https://github.com/townofus-pl/AleLuduMod/issues/6