### PR TITLE
Add compatibility with TOU Mira and other MiraAPI Mods

### DIFF
--- a/src/AleLuduMod/AleLuduMod.csproj
+++ b/src/AleLuduMod/AleLuduMod.csproj
@@ -11,7 +11,7 @@
     </PropertyGroup>
     <PropertyGroup>
         <GamePlatform Condition="'$(GamePlatform)' == ''">Steam</GamePlatform>
-        <GameVersion>2025.3.25</GameVersion>
+        <GameVersion>2025.9.9</GameVersion>
     </PropertyGroup>
     <ItemGroup>
         <PackageReference Include="Reactor" Version="2.4.0-ci.344" />

--- a/src/AleLuduMod/AleLuduModPlugin.cs
+++ b/src/AleLuduMod/AleLuduModPlugin.cs
@@ -22,9 +22,13 @@ public partial class AleLuduModPlugin : BasePlugin
 
     public override void Load()
     { 
-        NormalGameOptionsV09.RecommendedImpostors = NormalGameOptionsV09.MaxImpostors = Enumerable.Repeat(36, 36).ToArray();
-        NormalGameOptionsV09.MinPlayers = Enumerable.Repeat(4, 36).ToArray();
-        HideNSeekGameOptionsV09.MinPlayers = Enumerable.Repeat(4, 36).ToArray();
+        NormalGameOptionsV10.RecommendedImpostors = NormalGameOptionsV10.MaxImpostors = Enumerable.Repeat(36, 36).ToArray();
+        NormalGameOptionsV10.MinPlayers = Enumerable.Repeat(4, 36).ToArray();
+        HideNSeekGameOptionsV10.MinPlayers = Enumerable.Repeat(4, 36).ToArray();
+
+        IL2CPPChainloader.Instance.Finished +=
+            ModCompatibility
+                .Initialize; // Initialise AFTER the mods are loaded to ensure maximum parity
 
         Force4Columns = Config.Bind("Settings", "Force 4 columns", true, "Always display 4 columns in meeting, vitals, etc.");
 

--- a/src/AleLuduMod/ModCompatibility.cs
+++ b/src/AleLuduMod/ModCompatibility.cs
@@ -1,0 +1,81 @@
+
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using BepInEx.Unity.IL2CPP;
+using HarmonyLib;
+using Reactor.Utilities;
+using UnityEngine;
+
+namespace AleLuduMod;
+
+public static class ModCompatibility
+{
+    public const string MiraApiGuid = "mira.api";
+    public static bool MiraApiLoaded { get; private set; }
+    private static BasePlugin MiraApiPlugin { get; set; }
+    private static Assembly MiraApiAssembly { get; set; }
+    private static Type[] MiraApiTypes { get; set; }
+    public static float XStart = -0.8f;
+    public static float YStart = 2.15f;
+    public static float XOffset = 1.95f;
+    public static float YOffset = -0.65f;
+
+    public static void Initialize()
+    {
+        InitMiraApi();
+    }
+
+    private static void InitMiraApi()
+    {
+        if (!IL2CPPChainloader.Instance.Plugins.TryGetValue(MiraApiGuid, out var value))
+        {
+            return;
+        }
+
+        MiraApiPlugin = (value.Instance as BasePlugin)!;
+        MiraApiAssembly = MiraApiPlugin.GetType().Assembly;
+
+        MiraApiTypes = AccessTools.GetTypesFromAssembly(MiraApiAssembly);
+        
+        var playerMenu = MiraApiTypes.First(t => t.Name == "CustomPlayerMenu");
+        var menuBegin = AccessTools.Method(playerMenu, "Begin", new [] {typeof(Func<PlayerControl, bool>), typeof(Action<PlayerControl?>)});
+
+        var compatType = typeof(ModCompatibility);
+        var harmony = new Harmony("aleludu.miraapi.patch");
+        harmony.Patch(menuBegin, null,
+            new HarmonyMethod(AccessTools.Method(compatType, nameof(BeginPostfix))));
+
+        MiraApiLoaded = true;
+        Logger<AleLuduModPlugin>.Message("MiraAPI was detected and patched");
+    }
+    public static void BeginPostfix(dynamic __instance, Func<PlayerControl, bool> playerMatch, Action<PlayerControl?> onClick)
+    {
+        var targets = __instance.potentialVictims as List<ShapeshifterPanel>;
+        if (targets == null || targets.Count() < 16 && !AleLuduModPlugin.Force4Columns.Value)
+        {
+            // dont change layout if players count is below 16
+            return;
+        }
+
+        var i = 0;
+
+        foreach (var panel in targets)
+        {
+            panel.gameObject.SetActive(true);
+
+            var row = i / 4;
+            var col = i % 4;
+            var buttonTransform = panel.transform;
+            buttonTransform.localScale *= 0.75f;
+            buttonTransform.localPosition = new Vector3(
+                XStart + XOffset * col * 1.1f - 2.65f,
+                YStart + YOffset * row * 0.865f - 0.65f,
+                buttonTransform.localPosition.z
+            );
+            i++;
+        }
+    }
+}

--- a/src/AleLuduMod/ModCompatibility.cs
+++ b/src/AleLuduMod/ModCompatibility.cs
@@ -71,8 +71,8 @@ public static class ModCompatibility
             var buttonTransform = panel.transform;
             buttonTransform.localScale *= 0.75f;
             buttonTransform.localPosition = new Vector3(
-                XStart + XOffset * col * 1.1f - 2.65f,
-                YStart + YOffset * row * 0.865f - 0.65f,
+                XStart + XOffset * col * 1.1f - 2.4f,
+                YStart + YOffset * row * 0.9255f - 0.65f,
                 buttonTransform.localPosition.z
             );
             i++;


### PR DESCRIPTION
This PR does what it says on the tin; it adjusts the custom player menus used in MiraAPI, which is used by TOU Mira, and a handful of other mira-based mods.
#### MiraAPI's CustomPlayerMenu
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/1a9b72f0-bde0-48ac-8690-18950295bdd1" />

#### Vanilla's Shapeshifter Menu
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/c9b44d46-9fd8-4aec-ac75-3b17efbf5775" />
